### PR TITLE
explicitly don't do integration tests during publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Install dependencies
       run: poetry install
 
-    - name: Run tests
-      run: poetry run pytest
+    - name: Run unit tests only
+      run: poetry run pytest -m "not integration"
 
     - name: Check version
       run: |

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,5 @@
 [pytest]
 addopts = --ignore=dev_env
 markers =
-    integration: marks tests as integration (select with '-m integration'),
+    integration: marks tests as integration tests (deselect with '-m "not integration"'),
     unit: fast local logic tests (select with '-m unit')


### PR DESCRIPTION
## Description
Fixes publish workflow by deselecting integration tests, which don't need to be ran during the publish phase.

## Related Issue

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Ran locally.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes