### PR TITLE
Change api connector returns

### DIFF
--- a/ppp_connectors/api_connectors/broker.py
+++ b/ppp_connectors/api_connectors/broker.py
@@ -1,6 +1,6 @@
 import httpx
 from httpx import Auth
-from typing import Optional, Dict, Any, Union, Iterable
+from typing import Optional, Dict, Any, Union, Iterable, Callable, ParamSpec, TypeVar
 from tenacity import retry, stop_after_attempt, wait_exponential, RetryError
 from ppp_connectors.helpers import setup_logger, combine_env_configs
 from functools import wraps
@@ -8,7 +8,10 @@ import inspect
 import os
 
 
-def log_method_call(func):
+P = ParamSpec("P")
+R = TypeVar("R")
+
+def log_method_call(func: Callable[P, R]) -> Callable[P, R]:
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         caller = func.__name__
@@ -288,7 +291,7 @@ class Broker:
             self._log(f"HTTP error: {he}")
             raise
 
-    def get(self, endpoint: str, params: Optional[Dict[str, Any]] = None, **kwargs):
+    def get(self, endpoint: str, params: Optional[Dict[str, Any]] = None, **kwargs) -> httpx.Response:
         """
         Convenience method for HTTP GET requests.
 
@@ -301,7 +304,7 @@ class Broker:
         """
         return self._make_request("GET", endpoint, params=params, **kwargs)
 
-    def post(self, endpoint: str, json: Optional[Dict[str, Any]] = None, **kwargs):
+    def post(self, endpoint: str, json: Optional[Dict[str, Any]] = None, **kwargs) -> httpx.Response:
         """
         Convenience method for HTTP POST requests.
 

--- a/ppp_connectors/api_connectors/flashpoint.py
+++ b/ppp_connectors/api_connectors/flashpoint.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, Optional
-from ppp_connectors.api_connectors.broker import Broker
+from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
+@bubble_broker_init_signature()
 class FlashpointConnector(Broker):
     """
     FlashpointConnector provides access to various Flashpoint API search and retrieval endpoints
@@ -20,26 +21,32 @@ class FlashpointConnector(Broker):
             "Authorization": f"Bearer {self.api_key}",
         })
 
+    @log_method_call
     def search_communities(self, query: str, **kwargs) -> Dict[str, Any]:
         """Search Flashpoint communities data."""
         return self.post("/sources/v2/communities", json={"query": query, **kwargs}).json()
 
+    @log_method_call
     def search_fraud(self, query: str, **kwargs) -> Dict[str, Any]:
         """Search Flashpoint fraud datasets."""
         return self.post("/sources/v2/fraud", json={"query": query, **kwargs}).json()
 
+    @log_method_call
     def search_marketplaces(self, query: str, **kwargs) -> Dict[str, Any]:
         """Search Flashpoint marketplace datasets."""
         return self.post("/sources/v2/markets", json={"query": query, **kwargs}).json()
 
+    @log_method_call
     def search_media(self, query: str, **kwargs) -> Dict[str, Any]:
         """Search OCR-processed media from Flashpoint."""
         return self.post("/sources/v2/media", json={"query": query, **kwargs}).json()
 
+    @log_method_call
     def get_media_object(self, media_id: str) -> Dict[str, Any]:
         """Retrieve metadata for a specific media object."""
         return self.get(f"/sources/v2/media/{media_id}").json()
 
+    @log_method_call
     def get_media_image(self, storage_uri: str) -> Dict[str, Any]:
         """Download image asset by storage_uri."""
         return self.get("/sources/v1/media/", params={"asset_id": storage_uri}).json()

--- a/ppp_connectors/api_connectors/flashpoint.py
+++ b/ppp_connectors/api_connectors/flashpoint.py
@@ -1,3 +1,4 @@
+import httpx
 from typing import Dict, Any, Optional
 from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
@@ -22,31 +23,31 @@ class FlashpointConnector(Broker):
         })
 
     @log_method_call
-    def search_communities(self, query: str, **kwargs) -> Dict[str, Any]:
+    def search_communities(self, query: str, **kwargs) -> httpx.Response:
         """Search Flashpoint communities data."""
-        return self.post("/sources/v2/communities", json={"query": query, **kwargs}).json()
+        return self.post("/sources/v2/communities", json={"query": query, **kwargs})
 
     @log_method_call
-    def search_fraud(self, query: str, **kwargs) -> Dict[str, Any]:
+    def search_fraud(self, query: str, **kwargs) -> httpx.Response:
         """Search Flashpoint fraud datasets."""
-        return self.post("/sources/v2/fraud", json={"query": query, **kwargs}).json()
+        return self.post("/sources/v2/fraud", json={"query": query, **kwargs})
 
     @log_method_call
-    def search_marketplaces(self, query: str, **kwargs) -> Dict[str, Any]:
+    def search_marketplaces(self, query: str, **kwargs) -> httpx.Response:
         """Search Flashpoint marketplace datasets."""
-        return self.post("/sources/v2/markets", json={"query": query, **kwargs}).json()
+        return self.post("/sources/v2/markets", json={"query": query, **kwargs})
 
     @log_method_call
-    def search_media(self, query: str, **kwargs) -> Dict[str, Any]:
+    def search_media(self, query: str, **kwargs) -> httpx.Response:
         """Search OCR-processed media from Flashpoint."""
-        return self.post("/sources/v2/media", json={"query": query, **kwargs}).json()
+        return self.post("/sources/v2/media", json={"query": query, **kwargs})
 
     @log_method_call
-    def get_media_object(self, media_id: str) -> Dict[str, Any]:
+    def get_media_object(self, media_id: str) -> httpx.Response:
         """Retrieve metadata for a specific media object."""
-        return self.get(f"/sources/v2/media/{media_id}").json()
+        return self.get(f"/sources/v2/media/{media_id}")
 
     @log_method_call
-    def get_media_image(self, storage_uri: str) -> Dict[str, Any]:
+    def get_media_image(self, storage_uri: str) -> httpx.Response:
         """Download image asset by storage_uri."""
-        return self.get("/sources/v1/media/", params={"asset_id": storage_uri}).json()
+        return self.get("/sources/v1/media/", params={"asset_id": storage_uri})

--- a/ppp_connectors/api_connectors/generic.py
+++ b/ppp_connectors/api_connectors/generic.py
@@ -1,6 +1,6 @@
+import httpx
 from typing import Dict, Any, Optional
 from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
-import httpx
 
 @bubble_broker_init_signature()
 class GenericConnector(Broker):

--- a/ppp_connectors/api_connectors/generic.py
+++ b/ppp_connectors/api_connectors/generic.py
@@ -1,13 +1,15 @@
 from typing import Dict, Any, Optional
-from ppp_connectors.api_connectors.broker import Broker
+from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 import httpx
 
+@bubble_broker_init_signature()
 class GenericConnector(Broker):
     """
     A flexible, minimal connector that allows sending arbitrary HTTP requests
     using the Broker infrastructure.
     """
 
+    @log_method_call
     def request(
         self,
         method: str,

--- a/ppp_connectors/api_connectors/ipqs.py
+++ b/ppp_connectors/api_connectors/ipqs.py
@@ -1,4 +1,5 @@
-from typing import Optional, Dict, Any
+import httpx
+from typing import Optional
 from urllib.parse import quote
 from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
@@ -23,7 +24,7 @@ class IPQSConnector(Broker):
         self.headers.update({"Content-Type": "application/json"})
 
     @log_method_call
-    def malicious_url(self, query: str, **kwargs) -> dict:
+    def malicious_url(self, query: str, **kwargs) -> httpx.Response:
         """
         Scan a URL using IPQualityScore's Malicious URL Scanner API.
 
@@ -32,7 +33,7 @@ class IPQSConnector(Broker):
             **kwargs: Optional parameters like 'strictness' or 'fast' to influence scan behavior.
 
         Returns:
-            dict: Parsed JSON response from the IPQS API.
+            httpx.Response: the httpx.Response object
         """
         encoded_query: str = quote(query, safe="")
-        return self.post(f"/url/", json={"url": query, "key": self.api_key, **kwargs}).json()
+        return self.post(f"/url/", json={"url": query, "key": self.api_key, **kwargs})

--- a/ppp_connectors/api_connectors/ipqs.py
+++ b/ppp_connectors/api_connectors/ipqs.py
@@ -1,15 +1,8 @@
-"""
-IPQS Connector
-
-This module provides a connector for IPQualityScore's Malicious URL Scanner API.
-The connector uses the shared Broker base class for HTTP operations, logging,
-and environment variable loading.
-"""
 from typing import Optional, Dict, Any
 from urllib.parse import quote
-from ppp_connectors.api_connectors.broker import Broker, log_method_call
+from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
-
+@bubble_broker_init_signature()
 class IPQSConnector(Broker):
     """
     A connector for the IPQualityScore Malicious URL Scanner API.

--- a/ppp_connectors/api_connectors/spycloud.py
+++ b/ppp_connectors/api_connectors/spycloud.py
@@ -1,7 +1,8 @@
 from typing import Dict, Any, Optional
-from ppp_connectors.api_connectors.broker import Broker
-import sys
+from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
+
+@bubble_broker_init_signature()
 class SpycloudConnector(Broker):
     """
     SpyCloudConnector provides typed methods to interact with various SpyCloud APIs, including:
@@ -18,6 +19,7 @@ class SpycloudConnector(Broker):
         self.ato_key = ato_key or self.env_config.get("SPYCLOUD_API_ATO_KEY")
         self.inv_key = inv_key or self.env_config.get("SPYCLOUD_API_INV_KEY")
 
+    @log_method_call
     def sip_cookie_domains(self, cookie_domains: str, **kwargs) -> Dict[str, Any]:
         """Query SIP cookie domain data."""
         if not self.sip_key:
@@ -29,6 +31,7 @@ class SpycloudConnector(Broker):
         }
         return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs).json()
 
+    @log_method_call
     def ato_breach_catalog(self, query: str, **kwargs) -> Dict[str, Any]:
         """Query ATO breach catalog."""
         if not self.ato_key:
@@ -41,6 +44,7 @@ class SpycloudConnector(Broker):
         params = {"query": query, **kwargs}
         return self._make_request("get", endpoint=endpoint, headers=headers, params=params).json()
 
+    @log_method_call
     def ato_search(self, search_type: str, query: str, **kwargs) -> Dict[str, Any]:
         """Search against SpyCloud's ATO breach dataset."""
         if not self.ato_key:
@@ -65,6 +69,7 @@ class SpycloudConnector(Broker):
         }
         return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs).json()
 
+    @log_method_call
     def investigations_search(self, search_type: str, query: str, **kwargs) -> Dict[str, Any]:
         """Search SpyCloud Investigations API by type and query."""
         if not self.inv_key:

--- a/ppp_connectors/api_connectors/spycloud.py
+++ b/ppp_connectors/api_connectors/spycloud.py
@@ -1,3 +1,4 @@
+import httpx
 from typing import Dict, Any, Optional
 from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
@@ -20,7 +21,7 @@ class SpycloudConnector(Broker):
         self.inv_key = inv_key or self.env_config.get("SPYCLOUD_API_INV_KEY")
 
     @log_method_call
-    def sip_cookie_domains(self, cookie_domains: str, **kwargs) -> Dict[str, Any]:
+    def sip_cookie_domains(self, cookie_domains: str, **kwargs) -> httpx.Response:
         """Query SIP cookie domain data."""
         if not self.sip_key:
             raise ValueError("SPYCLOUD_API_SIP_KEY is required for this request.")
@@ -29,10 +30,10 @@ class SpycloudConnector(Broker):
             "accept": "application/json",
             "x-api-key": self.sip_key
         }
-        return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs).json()
+        return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs)
 
     @log_method_call
-    def ato_breach_catalog(self, query: str, **kwargs) -> Dict[str, Any]:
+    def ato_breach_catalog(self, query: str, **kwargs) -> httpx.Response:
         """Query ATO breach catalog."""
         if not self.ato_key:
             raise ValueError("SPYCLOUD_API_ATO_KEY is required for this request.")
@@ -42,10 +43,10 @@ class SpycloudConnector(Broker):
             "x-api-key": self.ato_key
         }
         params = {"query": query, **kwargs}
-        return self._make_request("get", endpoint=endpoint, headers=headers, params=params).json()
+        return self._make_request("get", endpoint=endpoint, headers=headers, params=params)
 
     @log_method_call
-    def ato_search(self, search_type: str, query: str, **kwargs) -> Dict[str, Any]:
+    def ato_search(self, search_type: str, query: str, **kwargs) -> httpx.Response:
         """Search against SpyCloud's ATO breach dataset."""
         if not self.ato_key:
             raise ValueError("SPYCLOUD_API_ATO_KEY is required for this request.")
@@ -67,10 +68,10 @@ class SpycloudConnector(Broker):
             "accept": "application/json",
             "x-api-key": self.ato_key
         }
-        return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs).json()
+        return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs)
 
     @log_method_call
-    def investigations_search(self, search_type: str, query: str, **kwargs) -> Dict[str, Any]:
+    def investigations_search(self, search_type: str, query: str, **kwargs) -> httpx.Response:
         """Search SpyCloud Investigations API by type and query."""
         if not self.inv_key:
             raise ValueError("SPYCLOUD_API_INV_KEY is required for this request.")
@@ -103,4 +104,4 @@ class SpycloudConnector(Broker):
             "accept": "application/json",
             "x-api-key": self.inv_key
         }
-        return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs).json()
+        return self._make_request("get", endpoint=endpoint, headers=headers, params=kwargs)

--- a/ppp_connectors/api_connectors/twilio.py
+++ b/ppp_connectors/api_connectors/twilio.py
@@ -1,6 +1,6 @@
 from datetime import date, datetime
 from typing import Dict, Any, List, Set, Union, Optional
-from httpx import BasicAuth
+from httpx import BasicAuth, Response
 from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 from ppp_connectors.helpers import validate_date_string
 
@@ -29,7 +29,7 @@ class TwilioConnector(Broker):
         self.auth = BasicAuth(self.api_sid, self.api_secret)
 
     @log_method_call
-    def lookup_phone(self, phone_number: str, data_packages: Optional[List[str]] = None, **kwargs) -> Dict[str, Any]:
+    def lookup_phone(self, phone_number: str, data_packages: Optional[List[str]] = None, **kwargs) -> Response:
         """
         Query information about a phone number using Twilio's Lookup API.
 
@@ -38,7 +38,7 @@ class TwilioConnector(Broker):
             data_packages (list): Optional data packages to include (e.g. 'caller_name', 'sim_swap').
 
         Returns:
-            dict: JSON response from Twilio.
+            httpx.Response: the httpx.Response object
         """
         valid_data_packages: Set[str] = {
             'caller_name', 'sim_swap', 'call_forwarding', 'line_status',
@@ -57,4 +57,4 @@ class TwilioConnector(Broker):
         }
 
         endpoint = f"/PhoneNumbers/{phone_number}"
-        return self._make_request("get", endpoint=endpoint, auth=self.auth, params=params).json()
+        return self._make_request("get", endpoint=endpoint, auth=self.auth, params=params)

--- a/ppp_connectors/api_connectors/twilio.py
+++ b/ppp_connectors/api_connectors/twilio.py
@@ -1,9 +1,10 @@
 from datetime import date, datetime
 from typing import Dict, Any, List, Set, Union, Optional
 from httpx import BasicAuth
-from ppp_connectors.api_connectors.broker import Broker
+from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 from ppp_connectors.helpers import validate_date_string
 
+@bubble_broker_init_signature()
 class TwilioConnector(Broker):
     """
     Connector for interacting with Twilio Lookup and Usage APIs.
@@ -27,6 +28,7 @@ class TwilioConnector(Broker):
 
         self.auth = BasicAuth(self.api_sid, self.api_secret)
 
+    @log_method_call
     def lookup_phone(self, phone_number: str, data_packages: Optional[List[str]] = None, **kwargs) -> Dict[str, Any]:
         """
         Query information about a phone number using Twilio's Lookup API.

--- a/ppp_connectors/api_connectors/urlscan.py
+++ b/ppp_connectors/api_connectors/urlscan.py
@@ -1,3 +1,4 @@
+import httpx
 from typing import Dict, Any, Optional
 from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
@@ -25,7 +26,7 @@ class URLScanConnector(Broker):
         })
 
     @log_method_call
-    def search(self, query: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def search(self, query: str, **kwargs: Dict[str, Any]) -> httpx.Response:
         """
         Search for archived scans matching a given query.
 
@@ -34,13 +35,13 @@ class URLScanConnector(Broker):
             **kwargs: Additional query parameters for filtering results.
 
         Returns:
-            dict: JSON response with matching scan metadata.
+            httpx.Response: the httpx.Response object
         """
         params = {"q": query, **kwargs}
-        return self.get("/search/", params=params).json()
+        return self.get("/search/", params=params)
 
     @log_method_call
-    def scan(self, query: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def scan(self, query: str, **kwargs: Dict[str, Any]) -> httpx.Response:
         """
         Submit a URL to be scanned by urlscan.io.
 
@@ -49,13 +50,13 @@ class URLScanConnector(Broker):
             **kwargs: Additional scan options like tags, visibility, or referer.
 
         Returns:
-            dict: JSON response containing the scan ID and status.
+            httpx.Response: the httpx.Response object
         """
         payload = {"url": query, **kwargs}
-        return self.post("/scan", json=payload).json()
+        return self.post("/scan", json=payload)
 
     @log_method_call
-    def results(self, uuid: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def results(self, uuid: str, **kwargs: Dict[str, Any]) -> httpx.Response:
         """
         Retrieve detailed scan results by UUID.
 
@@ -63,12 +64,12 @@ class URLScanConnector(Broker):
             uuid (str): The UUID of the scan.
 
         Returns:
-            dict: JSON response with scan results and metadata.
+            httpx.Response: the httpx.Response object
         """
-        return self.get(f"/result/{uuid}", params=kwargs).json()
+        return self.get(f"/result/{uuid}", params=kwargs)
 
     @log_method_call
-    def get_dom(self, uuid: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def get_dom(self, uuid: str, **kwargs: Dict[str, Any]) -> httpx.Response:
         """
         Retrieve the DOM snapshot for a given scan UUID.
 
@@ -76,12 +77,12 @@ class URLScanConnector(Broker):
             uuid (str): The UUID of the scan.
 
         Returns:
-            dict: JSON response with the scanned DOM content.
+            httpx.Response: the httpx.Response object
         """
-        return self.get(f"https://urlscan.io/dom/{uuid}", params=kwargs).json()
+        return self.get(f"https://urlscan.io/dom/{uuid}", params=kwargs)
 
     @log_method_call
-    def structure_search(self, uuid: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def structure_search(self, uuid: str, **kwargs: Dict[str, Any]) -> httpx.Response:
         """
         Search for scans structurally similar to a given UUID.
 
@@ -89,6 +90,6 @@ class URLScanConnector(Broker):
             uuid (str): The UUID of the original scan.
 
         Returns:
-            dict: JSON response with similar scan entries.
+            httpx.Response: the httpx.Response object
         """
-        return self.get(f"/pro/result/{uuid}/similar", params=kwargs).json()
+        return self.get(f"/pro/result/{uuid}/similar", params=kwargs)

--- a/ppp_connectors/api_connectors/urlscan.py
+++ b/ppp_connectors/api_connectors/urlscan.py
@@ -1,13 +1,7 @@
 from typing import Dict, Any, Optional
-from ppp_connectors.api_connectors.broker import Broker
+from ppp_connectors.api_connectors.broker import Broker, bubble_broker_init_signature, log_method_call
 
-"""
-URLScan Connector
-
-This module provides a typed connector for the urlscan.io API, built on the Broker class.
-It supports searching, scanning, and retrieving structured results for analyzed URLs.
-"""
-
+@bubble_broker_init_signature()
 class URLScanConnector(Broker):
     """
     A connector for interacting with the urlscan.io API.
@@ -30,6 +24,7 @@ class URLScanConnector(Broker):
             "API-Key": self.api_key
         })
 
+    @log_method_call
     def search(self, query: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """
         Search for archived scans matching a given query.
@@ -44,6 +39,7 @@ class URLScanConnector(Broker):
         params = {"q": query, **kwargs}
         return self.get("/search/", params=params).json()
 
+    @log_method_call
     def scan(self, query: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """
         Submit a URL to be scanned by urlscan.io.
@@ -58,6 +54,7 @@ class URLScanConnector(Broker):
         payload = {"url": query, **kwargs}
         return self.post("/scan", json=payload).json()
 
+    @log_method_call
     def results(self, uuid: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """
         Retrieve detailed scan results by UUID.
@@ -70,6 +67,7 @@ class URLScanConnector(Broker):
         """
         return self.get(f"/result/{uuid}", params=kwargs).json()
 
+    @log_method_call
     def get_dom(self, uuid: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """
         Retrieve the DOM snapshot for a given scan UUID.
@@ -82,6 +80,7 @@ class URLScanConnector(Broker):
         """
         return self.get(f"https://urlscan.io/dom/{uuid}", params=kwargs).json()
 
+    @log_method_call
     def structure_search(self, uuid: str, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """
         Search for scans structurally similar to a given UUID.

--- a/ppp_connectors/tests/test_flashpoint/test_integration_flashpoint.py
+++ b/ppp_connectors/tests/test_flashpoint/test_integration_flashpoint.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from ppp_connectors.api_connectors.flashpoint import FlashpointConnector
 
@@ -6,5 +7,5 @@ def test_flashpoint_search_fraud_vcr(vcr_cassette):
     with vcr_cassette.use_cassette("test_flashpoint_search_fraud_vcr"):
         connector = FlashpointConnector(load_env_vars=True)
         result = connector.search_fraud("dark web")
-        assert isinstance(result, dict)
-        assert "items" in result
+        assert isinstance(result, httpx.Response)
+        assert "items" in result.json()

--- a/ppp_connectors/tests/test_ipqs/test_integration_ipqs.py
+++ b/ppp_connectors/tests/test_ipqs/test_integration_ipqs.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from ppp_connectors.api_connectors.ipqs import IPQSConnector
 
@@ -7,6 +8,6 @@ def test_ipqs_malicious_url_vcr(vcr_cassette):
         connector = IPQSConnector(load_env_vars=True, enable_logging=True)
         result = connector.malicious_url("github.com")
 
-        assert isinstance(result, dict)
-        assert "domain" in result
-        assert result["domain"] == "github.com"
+        assert isinstance(result, httpx.Response)
+        assert "domain" in result.json()
+        assert result.json()["domain"] == "github.com"

--- a/ppp_connectors/tests/test_spycloud/test_integration_spycloud.py
+++ b/ppp_connectors/tests/test_spycloud/test_integration_spycloud.py
@@ -1,7 +1,5 @@
-
-
+import httpx
 import pytest
-import vcr
 from ppp_connectors.api_connectors.spycloud import SpycloudConnector
 
 @pytest.mark.integration
@@ -10,5 +8,5 @@ def test_spycloud_ato_search_vcr(vcr_cassette):
         connector = SpycloudConnector(load_env_vars=True, enable_logging=True)
         result = connector.ato_search(search_type="ip", query="8.8.8.8")
 
-        assert isinstance(result, dict)
-        assert "results" in result
+        assert isinstance(result, httpx.Response)
+        assert "results" in result.json()

--- a/ppp_connectors/tests/test_twilio/test_integration_twilio.py
+++ b/ppp_connectors/tests/test_twilio/test_integration_twilio.py
@@ -1,5 +1,5 @@
 
-
+import httpx
 import pytest
 import vcr
 from ppp_connectors.api_connectors.twilio import TwilioConnector
@@ -10,5 +10,5 @@ def test_lookup_phone_vcr(vcr_cassette):
         connector = TwilioConnector(load_env_vars=True)
         result = connector.lookup_phone("+14155552671")
 
-        assert isinstance(result, dict)
-        assert "phone_number" in result or "caller_name" in result or "line_type" in result
+        assert isinstance(result, httpx.Response)
+        assert "phone_number" in result.json() or "caller_name" in result.json() or "line_type" in result.json()

--- a/ppp_connectors/tests/test_urlscan/test_integration_urlscan.py
+++ b/ppp_connectors/tests/test_urlscan/test_integration_urlscan.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 from ppp_connectors.api_connectors.urlscan import URLScanConnector
 
@@ -6,4 +7,6 @@ def test_urlscan_results_vcr(vcr_cassette):
     with vcr_cassette.use_cassette("test_urlscan_results_vcr"):
         connector = URLScanConnector(load_env_vars=True, enable_logging=True)
         result = connector.results("01958568-c986-7001-816d-9e0ccd7c4c4a")
-        assert "task" in result
+
+        assert isinstance(result, httpx.Response)
+        assert "task" in result.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ppp-connectors"
 packages = [{ include = "ppp_connectors" }]
-version = "1.0.6"
+version = "1.0.7"
 description = "A simple, lightweight set of connectors and functions to various APIs and DBMSs, controlled by a central broker."
 authors = ["Rob D'Aveta <rob.daveta@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Description
- API connectors return httpx.Response objects instead of .json()
- the Broker class now bubbles up all its parameters to API connectors for tab-completion
- updated all tests where applicable

## Related Issue

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Updated unit and integration tests to follow the new response pattern

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes