### PR TITLE
Upsert many supports list or string

### DIFF
--- a/dev_env/mongo/test_mongo_async.py
+++ b/dev_env/mongo/test_mongo_async.py
@@ -43,6 +43,47 @@ async def main() -> None:
         ]
         await client.upsert_many(db, col, upserts, unique_key="_id", ordered=False, batch_size=100)
 
+        # --- TEST CASE 1: upsert_many with single-field unique_key (string) ---
+        logger.info("[async] Testing upsert_many with single-field unique_key (string)...")
+        await client.delete_many(db, col, {"_sample_single": True})
+        docs_single = [
+            {"email": "alice@example.com", "score": 10, "_sample_single": True},
+            {"email": "bob@example.com", "score": 20, "_sample_single": True},
+        ]
+        await client.insert_many(db, col, docs_single, ordered=False)
+        upserts_single = [
+            {"email": "bob@example.com", "score": 99, "_sample_single": True},  # Should update
+            {"email": "carol@example.com", "score": 30, "_sample_single": True},  # Should insert
+        ]
+        await client.upsert_many(db, col, upserts_single, unique_key="email")
+        logger.info("[async] Verifying single-field upsert results:")
+        async for doc in client.find(
+            db_name=db, collection=col, filter={"_sample_single": True}, projection={"_id": 0}
+        ):
+            print("[single-key upsert]", doc)
+
+        # --- TEST CASE 2: upsert_many with compound unique_key (list of strings) ---
+        logger.info("[async] Testing upsert_many with compound unique_key (list of strings)...")
+        await client.delete_many(db, col, {"_sample_compound": True})
+        docs_compound = [
+            {"scan_uuid": "A1", "domain": "foo.com", "score": 5, "_sample_compound": True},
+            {"scan_uuid": "A1", "domain": "bar.com", "score": 6, "_sample_compound": True},
+            {"scan_uuid": "B2", "domain": "baz.com", "score": 7, "_sample_compound": True},
+        ]
+        await client.insert_many(db, col, docs_compound, ordered=False)
+        upserts_compound = [
+            # This should update an existing doc (A1, foo.com)
+            {"scan_uuid": "A1", "domain": "foo.com", "score": 55, "_sample_compound": True},
+            # This should insert a new doc (A1, qux.com)
+            {"scan_uuid": "A1", "domain": "qux.com", "score": 66, "_sample_compound": True},
+        ]
+        await client.upsert_many(db, col, upserts_compound, unique_key=["scan_uuid", "domain"])
+        logger.info("[async] Verifying compound-key upsert results:")
+        async for doc in client.find(
+            db_name=db, collection=col, filter={"_sample_compound": True}, projection={"_id": 0}
+        ):
+            print("[compound-key upsert]", doc)
+
         logger.info("[async] Finding _sample docs with projection and small batch size...")
         async for doc in client.find(
             db_name=db,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ppp-connectors"
 packages = [{ include = "ppp_connectors" }]
-version = "1.1.6"
+version = "1.1.7"
 description = "A simple, lightweight set of connectors and functions to various APIs and DBMSs, controlled by a central broker."
 authors = ["Rob D'Aveta <rob.daveta@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Description
upsert_many now supports providing a unique_key of type list or type string

## Related Issue

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
local integration testing

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes